### PR TITLE
Ensure sections are expanded when they are the current page

### DIFF
--- a/layouts/partials/theme/sidebar-content.html
+++ b/layouts/partials/theme/sidebar-content.html
@@ -49,7 +49,7 @@
     {{end}}
     <div {{if eq .FirstSection .}}class='is-expandable'{{end}}>
       <div {{if eq .FirstSection .}}class='is-sidebar-list-wrapper'{{end}}>
-        <li class='is-marginless{{if $sidebarRoot.Scratch.Get "isTreeActive"}} is-tree-active{{end}}{{if gt $linkWeight 0}} is-entries-expandable{{if .IsAncestor $sidebarRoot}} is-entries-expanded{{else}} is-entries-shrinked{{end}}{{end}}'>
+        <li class='is-marginless{{if $sidebarRoot.Scratch.Get "isTreeActive"}} is-tree-active{{end}}{{if gt $linkWeight 0}} is-entries-expandable{{if .IsAncestor $sidebarRoot | or (eq $sidebarRoot .) }} is-entries-expanded{{else}} is-entries-shrinked{{end}}{{end}}'>
           <div class='card{{if $sidebarRoot.Scratch.Get "isSidebarActive"}} is-sidebar-active{{end}}'{{if $sidebarRoot.Scratch.Get "isSidebarActive"}} id='sidebarActiveEntry'{{end}}>
             {{template "sidebarSectionIcon" dict "this" . "sidebarroot" $sidebarRoot "linkWeight" $linkWeight "isLabel" true}}
             {{if gt $linkWeight 0}}


### PR DESCRIPTION
The example site at https://shadocs.netlify.app/ already works this way. But it looks like newer versions of hugo have changed how the `IsAncestor` works. This change makes sure that the section pages show expended content in the sidebar when they are the current page. This change does this regardless of the hugo version used for rendering

TL;DR

Builds using hugo [v0.100.0](https://github.com/gohugoio/hugo/releases/tag/v0.100.0) or later won't render correctly without this.