### PR TITLE
Fix layout of search results.

### DIFF
--- a/assets/sass/theme/search.sass
+++ b/assets/sass/theme/search.sass
@@ -35,7 +35,9 @@
   position: absolute
   border-radius: 0
   overflow-y: auto
-  min-width: 100%
+  width: $navbar-search-results-width
+  +touch
+    width: $navbar-search-results-width-touch
   z-index: 1
   strong
     color: $navbar-search-highlight-color !important
@@ -66,28 +68,21 @@
       font-weight: 900
       cursor: unset
     a
-      max-width: $navbar-search-results-width
       @extend %search-content-colors
       min-height: $control-height
-      width: max-content
-      min-width: 100%
       +touch
         max-width: $navbar-search-results-width-touch
       .level-left
-        width: calc((#{$navbar-search-results-width} * 75) / 100)
+        width: 75%
         min-height: $control-height
         position: relative
-        +touch
-          width: calc((#{$navbar-search-results-width-touch} * 75) / 100)
         .scontent
-          width: calc((#{$navbar-search-results-width} * 75) / 100)
+          width: 75%
           padding: $theme-gap-medium-size
           word-break: break-word
           justify-content: left
           flex-wrap: wrap
           display: block
-          +touch
-            width: calc((#{$navbar-search-results-width-touch} * 75) / 100)
         &:after
           background: smooth-color(findColorInvert($content-background), 50)
           position: absolute
@@ -96,19 +91,15 @@
           width: 1px
           right: 0
       .level-right
-        width: calc((#{$navbar-search-results-width} * 25) / 100)
+        width: 25%
         min-height: $control-height
-        +touch
-          width: calc((#{$navbar-search-results-width-touch} * 25) / 100)
         .spath
-          width: calc((#{$navbar-search-results-width} * 25) / 100)
+          width: 25%
           padding: $theme-gap-medium-size
           justify-content: right
           word-break: break-word
           text-align: right
           flex-wrap: wrap
-          +touch
-            width: calc((#{$navbar-search-results-width-touch} * 25) / 100)
       .level-item
         min-height: $control-height
         &.spre


### PR DESCRIPTION
The current layout causes the page title of search results to be cut off
by the scroll bar, when it is visible.

This change simplifies the logic that determines widths. Instead of
calculating each component, only the search result container is based
on the configured width. Components are then calculated relative to the
container. Because of this, they are no longer cut off by the scroll
bar.