### PR TITLE
Use thinner content padding on mobile.

### DIFF
--- a/assets/sass/theme/content.sass
+++ b/assets/sass/theme/content.sass
@@ -37,8 +37,12 @@
     text-align: center
     font-weight: 700
   #content
-    padding-right: $navbar-height
-    padding-left: $navbar-height
+    +mobile
+      padding-right: $theme-gap-medium-size
+      padding-left: $theme-gap-medium-size
+    +tablet
+      padding-right: $navbar-height
+      padding-left: $navbar-height
     +static-size-width(100%)
     position: relative
     &:after

--- a/assets/sass/theme/home.sass
+++ b/assets/sass/theme/home.sass
@@ -1,6 +1,10 @@
 #contentHome
-  padding-right: $navbar-height
-  padding-left: $navbar-height
+  +mobile
+    padding-right: $theme-gap-medium-size
+    padding-left: $theme-gap-medium-size
+  +tablet
+    padding-right: $navbar-height
+    padding-left: $navbar-height
   +static-size-width(100%)
   justify-content: center
   flex-direction: column


### PR DESCRIPTION
I feel that, on tiny screen sizes, the padding is unreasonably large and squeezes the content. This changes causes the padding to be reduced for mobile screen sizes.

Comparison:
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before](https://user-images.githubusercontent.com/918097/182204923-888d5ac0-d25a-460d-abd5-42f8b3ba13a9.png)
</td>
<td>

![after](https://user-images.githubusercontent.com/918097/182204936-16443d27-f143-4f60-b8f6-fd5d5a4bf926.png)

</td>
</tr>
</table>

I chose to use `$theme-gap-medium-size` (`.5rem`) for the width, because it appears to match padding that occurs elsewhere. If it seems too thin, `$theme-gap-size` (`.75rem`) or `$theme-gap-large-size` (`1rem`) look like reasonable alternatives.
