### PR TITLE
PostCSS: get rid of option 'includePaths'

### DIFF
--- a/assets/sass/theme/main.sass
+++ b/assets/sass/theme/main.sass
@@ -1,11 +1,11 @@
 @charset "utf-8"
 @import "pre_variables";
 @import "pre_variables-bulma";
-@import "custom_pre_variables";
-@import "bulma";
+@import "../custom/custom_pre_variables";
+@import "../../bulma/bulma";
 @import "functions";
 @import "variables";
-@import "custom_variables";
+@import "../custom/custom_variables";
 @import "mixins";
 @import "extends";
 @import "animations";

--- a/exampleSite/content/english/functionalities/thirdparty_imports.md
+++ b/exampleSite/content/english/functionalities/thirdparty_imports.md
@@ -17,12 +17,10 @@ The several types of imports managed by the theme are the following ones:
 | Import type | Comment |
 | ----------- | ------- |
 | **SASS files** (.sass) |{{< md >}}
-* Imported in `<head>` tag as `<link rel="stylesheet" type="text/css">` after being [converted as CSS by Hugo](https://gohugo.io/hugo-pipes/transform-to-css/), grouped and minified in **main.css** file
+* Imported in `<head>` tag as `<link rel="stylesheet" type="text/css">` after being [converted as CSS by Hugo](https://gohugo.io/hugo-pipes/transform-to-css/), grouped and minified in **css/main.css** file
 * Paths used for the SASS➔CSS conversion :
     * assets/bulma
     * assets/sass
-    * assets/sass/theme
-    * assets/sass/custom
 {{< /md >}}|
 | **CSS files** (.css) |{{< md >}}
 * Imported file by file in `<head>` tag as `<link rel="stylesheet" type="text/css">` and minified

--- a/exampleSite/content/english/theme/extend.md
+++ b/exampleSite/content/english/theme/extend.md
@@ -64,9 +64,6 @@ The following files are managed within the theme:
 * **assets/sass/custom/custom_pre_variables.sass** to override [bulma variables](https://bulma.io/documentation/customize/variables/) as well as [primary theme variables](https://github.com/jgazeau/shadocs/blob/main/assets/sass/theme/pre_variables.sass)
 * **assets/sass/custom/custom_variables.sass** to override [secondary theme variables](https://github.com/jgazeau/shadocs/blob/main/assets/sass/theme/variables.sass)
 
-{{< alert type="warning" >}}
-If specific SASS customization is choosed, all custom files must exist (and left empty if nothing has to be overriden) within the **assets/sass/custom** folder (e.g. [documentation website SASS assets folder](https://github.com/jgazeau/shadocs/tree/main/exampleSite/assets/sass/custom))
-{{< /alert >}}
 {{< alert type="info" >}}
 For more information, check the documentation website [custom_variables.sass](https://github.com/jgazeau/shadocs/blob/main/exampleSite/assets/sass/custom/custom_variables.sass) and [example.sass](https://github.com/jgazeau/shadocs/blob/main/exampleSite/assets/sass/custom/example.sass), to implement specific CSS behavior:
 ### Specific title color for custom SASS example {#sass_custom_example}

--- a/exampleSite/content/french/functionalities/thirdparty_imports.md
+++ b/exampleSite/content/french/functionalities/thirdparty_imports.md
@@ -17,12 +17,10 @@ Les différents types d'imports gérés par le thème sont les suivants:
 | Type d'import | Commentaire |
 | ------------- | ----------- |
 | **Fichiers SASS** (.sass) |{{< md >}}
-* Importés dans la balise `<head>` en tant que `<link rel="stylesheet" type="text/css">` après avoir été [convertis en CSS par Hugo](https://gohugo.io/hugo-pipes/transform-to-css/), regroupés et minifiés dans un fichier **main.css**
+* Importés dans la balise `<head>` en tant que `<link rel="stylesheet" type="text/css">` après avoir été [convertis en CSS par Hugo](https://gohugo.io/hugo-pipes/transform-to-css/), regroupés et minifiés dans un fichier **css/main.css**
 * Les chemins utilisés pour la conversion SASS➔CSS:
     * assets/bulma
     * assets/sass
-    * assets/sass/theme
-    * assets/sass/custom
 {{< /md >}}|
 | **Fichiers CSS** (.css) |{{< md >}}
 * Importés fichier par fichier dans la balise `<head>` en tant que `<link rel="stylesheet" type="text/css">` et minifiés

--- a/exampleSite/content/french/theme/extend.md
+++ b/exampleSite/content/french/theme/extend.md
@@ -64,9 +64,6 @@ Les fichiers suivants sont gérés dans le thème:
 * **assets/sass/custom/custom_pre_variables.sass** pour surcharger les [variables bulma](https://bulma.io/documentation/customize/variables/) de même que les [variables primaires du thème](https://github.com/jgazeau/shadocs/blob/main/assets/sass/theme/pre_variables.sass)
 * **assets/sass/custom/custom_variables.sass** pour surcharger les [variables secondaires du thème](https://github.com/jgazeau/shadocs/blob/main/assets/sass/theme/variables.sass)
 
-{{< alert type="warning" >}}
-Si la personnalisation SASS est choisie, tout les fichiers specifiques doivent exister (et laissés vide si rien ne doit être surchargé) dans le dossier **assets/sass/custom** (e.g. [dossier des assets du site de documentation](https://github.com/jgazeau/shadocs/tree/main/exampleSite/assets/sass/custom))
-{{< /alert >}}
 {{< alert type="info" >}}
 Pour plus d'information, se référer au fichier du site de documentation [custom_variables.sass](https://github.com/jgazeau/shadocs/blob/main/exampleSite/assets/sass/custom/custom_variables.sass) et [example.sass](https://github.com/jgazeau/shadocs/blob/main/exampleSite/assets/sass/custom/example.sass), pour implémenter un comportement CSS spécifique:
 ### Couleur de titre spécifique pour exemple de personnalisation SASS {#sass_custom_example}

--- a/layouts/partials/theme/includes-head.html
+++ b/layouts/partials/theme/includes-head.html
@@ -67,8 +67,8 @@
   {{- range .this | uniq -}}
     {{- $filesArray = $filesArray | append (resources.Get .) -}}
   {{- end -}}
-  {{- $options := (dict "outputStyle" "compressed" "includePaths" (slice "assets/bulma" "assets/sass/theme" "assets/sass/custom" "assets/sass")) -}}
-  {{- $cssFile := $filesArray | resources.Concat "css/main.sass" | resources.ToCSS $options -}}
+  {{- $options := (dict "outputStyle" "compressed") -}}
+  {{- $cssFile := $filesArray | resources.Concat "sass/theme/bundle.sass" | resources.ToCSS $options -}}
   <link
     rel="stylesheet"
     rel="preload"

--- a/layouts/partials/theme/includes-head.html
+++ b/layouts/partials/theme/includes-head.html
@@ -67,7 +67,7 @@
   {{- range .this | uniq -}}
     {{- $filesArray = $filesArray | append (resources.Get .) -}}
   {{- end -}}
-  {{- $options := (dict "outputStyle" "compressed") -}}
+  {{- $options := (dict "outputStyle" "compressed" "targetPath" "css/main.css") -}}
   {{- $cssFile := $filesArray | resources.Concat "sass/theme/bundle.sass" | resources.ToCSS $options -}}
   <link
     rel="stylesheet"


### PR DESCRIPTION
This PR aims at simplifying the PostCSS tool chain used with this theme by discarding the option `includePaths` used by the `ToCSS`function. This PR paves the way for #147.