### PR TITLE
Language selector: simplify code

### DIFF
--- a/layouts/partials/theme/lang-selector.html
+++ b/layouts/partials/theme/lang-selector.html
@@ -22,20 +22,13 @@
   >
     <div class="dropdown-content is-paddingless">
       {{- range $.Page.AllTranslations -}}
-        {{- $.Scratch.Set "translatedLang" .Language.Lang -}}
-        {{- $.Scratch.Set "translatedUrl" "" -}}
-        {{- range $.Page.Translations -}}
-          {{- if eq .Language.Lang ($.Scratch.Get "translatedLang") -}}
-            {{- $.Scratch.Set "translatedUrl" (.RelPermalink | safeURL) -}}
-          {{- end -}}
-        {{- end -}}
         {{- if eq $.Site.Language.LanguageName .Language.LanguageName -}}
           <div class="dropdown-item is-selected has-text-weight-bold">
             {{- .Language.LanguageName -}}
           </div>
         {{- else -}}
           <a
-            href="{{- $.Scratch.Get "translatedUrl" -}}"
+            href="{{- .RelPermalink | safeURL -}}"
             class="dropdown-item has-text-weight-bold"
           >
             {{- .Language.LanguageName -}}


### PR DESCRIPTION
This PR follows up on my [discussion comment](https://github.com/jgazeau/shadocs/issues/156#issuecomment-1485020164) in #156. It simplifies the language selector code. IMO, we can safely remove 7 lines here while still getting exact same behaviour as before. 