### PR TITLE
i18n: consolidate duplicate messages

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -110,9 +110,5 @@
   translation: 'Erledigt'
 - id: na_common
   translation: 'Nicht verfügbar'
-- id: sidebar_collapsible_title
-  translation: 'Seitenleiste ein-/ausklappen'
-- id: toc_collapsible_title
-  translation: 'Inhaltsverzeichnis ein-/ausklappen'
 - id: highcharts_error
   translation: 'Service für Anzeige des Highcharts-Diagramms nicht verfügbar'

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -53,7 +53,7 @@
 - id: 6_toggletoc_keys_wording
   translation: 'Shift,t'
 - id: 6_toggletoc_wording
-  translation: 'Collapse/Uncollapse toc'
+  translation: 'Collapse/Uncollapse table of contents'
 - id: 7_backtotop_keys_wording
   translation: 'Shift,↑'
 - id: 7_backtotop_wording
@@ -110,9 +110,5 @@
   translation: 'Done'
 - id: na_common
   translation: 'Not available'
-- id: sidebar_collapsible_title
-  translation: 'Collapse/Uncollapse sidebar'
-- id: toc_collapsible_title
-  translation: 'Collapse/Uncollapse table of contents'
 - id: highcharts_error
   translation: 'Highcharts rendering unavailable'

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -110,9 +110,5 @@
   translation: 'Terminer'
 - id: na_common
   translation: 'Non disponible'
-- id: sidebar_collapsible_title
-  translation: 'Développer/Réduire menu latéral'
-- id: toc_collapsible_title
-  translation: 'Développer/Réduire table des matières'
 - id: highcharts_error
   translation: 'Rendu du Highcharts non disponible'

--- a/layouts/partials/theme/sidebar.html
+++ b/layouts/partials/theme/sidebar.html
@@ -15,7 +15,7 @@
         <div
           id="sidebarUncollapse"
           class="card-header is-single-link"
-          title="{{- i18n "sidebar_collapsible_title" -}}"
+          title="{{- i18n "5_togglesidebar_wording" -}}"
         >
           <a class="card-header-title">
             <i class="fa-solid fa-angles-right fa-lg"></i>
@@ -26,7 +26,7 @@
         <div
           id="sidebarCollapse"
           class="card-header is-single-link"
-          title="{{- i18n "sidebar_collapsible_title" -}}"
+          title="{{- i18n "5_togglesidebar_wording" -}}"
         >
           <a class="card-header-title">
             <i class="fa-solid fa-angles-left fa-lg"></i>

--- a/layouts/partials/theme/toc.html
+++ b/layouts/partials/theme/toc.html
@@ -43,7 +43,7 @@
   <div
     class="is-paddingless"
     id="tocCollapsible"
-    title="{{- i18n "toc_collapsible_title" -}}"
+    title="{{- i18n "6_toggletoc_wording" -}}"
   >
     <i class="fa-solid fa-angles-right fa-lg"></i>
   </div>


### PR DESCRIPTION
This PR follows up on my [comment](https://github.com/jgazeau/shadocs/pull/152#issue-1640817360) given in #152. It removes two duplicates from the language files, thus eliminating redundancy here.