### PR TITLE
HTML Validation: Fix error 'No space between attributes.'

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,7 +7,7 @@
   {{- with .Title -}}
     title="{{- . -}}" id="{{- . | anchorize -}}"
   {{- end -}}
-  {{- with $simpleLink -}}
+  {{- with $simpleLink }}
     class="is-pretty-link"
   {{- end -}}
   >{{- .Text | safeHTML -}}</a

--- a/layouts/partials/theme/sidebar-content.html
+++ b/layouts/partials/theme/sidebar-content.html
@@ -139,7 +139,7 @@
       <a
         href='{{- .this.RelPermalink | safeURL -}}'
         class='card-header-title'
-        {{- if .isLabel -}}
+        {{- if .isLabel }}
           title='{{- .this.LinkTitle -}}'
         {{- end -}}
       >


### PR DESCRIPTION
Run the [w3c validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fshadocs.netlify.app) on the example site of this repo. Several errors are reported.
This PR fixes the all errors of kind:

```
No space between attributes.
```