### PR TITLE
HTML validation: fix error 'Attribute data not allowed'

### DIFF
--- a/assets/js/shortcodes/intro.js
+++ b/assets/js/shortcodes/intro.js
@@ -58,13 +58,13 @@ const themeCommonOptions = {
   disableInteraction: true,
 };
 const introErrorTitle = atou(
-  document.getElementById('intro-error-title').getAttribute('data')
+  document.getElementById('intro-error-title').getAttribute('data-intro')
 );
 const introError = atou(
-  document.getElementById('intro-error').getAttribute('data')
+  document.getElementById('intro-error').getAttribute('data-intro')
 );
 const introEmpty = atou(
-  document.getElementById('intro-empty').getAttribute('data')
+  document.getElementById('intro-empty').getAttribute('data-intro')
 );
 const introErrorStep = {
   showBullets: false,
@@ -90,7 +90,7 @@ for (let i = 0; i < divi.length; i++) {
   divi[i].addEventListener('click', function () {
     disableSmoothScroll();
     let introOptions = parseIntroOptions(
-      atou(divi[i].getAttribute('intro-data'))
+      atou(divi[i].getAttribute('data-intro'))
     );
     introOptions.steps = manageTriggeredSteps(
       introOptions.steps,

--- a/layouts/shortcodes/intro.html
+++ b/layouts/shortcodes/intro.html
@@ -13,24 +13,24 @@
   {{- if eq ($.Page.Scratch.Get "introUid") 1 -}}
     <div
       id="intro-error-title"
-      data="{{- i18n "intro_error_title" | safeJS | base64Encode -}}"
+      data-intro="{{- i18n "intro_error_title" | safeJS | base64Encode -}}"
       class="is-hidden"
     ></div>
     <div
       id="intro-error"
-      data="{{- i18n "intro_error" | safeJS | base64Encode -}}"
+      data-intro="{{- i18n "intro_error" | safeJS | base64Encode -}}"
       class="is-hidden"
     ></div>
     <div
       id="intro-empty"
-      data="{{- i18n "intro_empty" | safeJS | base64Encode -}}"
+      data-intro="{{- i18n "intro_empty" | safeJS | base64Encode -}}"
       class="is-hidden"
     ></div>
   {{- end -}}
   <div
     class="sc-intro"
     id="{{- $.Scratch.Get "introId" -}}"
-    intro-data="{{- . | safeJS | base64Encode -}}"
+    data-intro="{{- . | safeJS | base64Encode -}}"
   >
     {{- $.Scratch.Get "introtitle" -}}
   </div>


### PR DESCRIPTION
Run the [w3c validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fshadocs.netlify.app) on the example site of this repo. Several errors are reported.
This PR fixes all errors of kind:

```
Attribute 'data' not allowed on element 'div' at this point.
```