### PR TITLE
Taxonomy selector: use correct url for href attribute

### DIFF
--- a/layouts/partials/theme/taxonomy-selector.html
+++ b/layouts/partials/theme/taxonomy-selector.html
@@ -23,7 +23,7 @@
     <div class="dropdown-content is-paddingless">
       {{- range $taxonomyname, $taxonomy := .Site.Taxonomies -}}
         {{- if gt (len $taxonomy) 0 -}}
-          {{- $.Scratch.Set "taxonomyUrl" (printf "%s%s%s" ("" | relLangURL) ($taxonomyname | urlize) "/") -}}
+          {{- $.Scratch.Set "taxonomyUrl" (printf "%s/%s%s" ("" | relLangURL) ($taxonomyname | urlize) "/") -}}
           {{- if eq $.Page.RelPermalink ($.Scratch.Get "taxonomyUrl") -}}
             <div class="dropdown-item is-selected has-text-weight-bold">
               {{- with $.Site.Params.taxonomies -}}


### PR DESCRIPTION
* Generate html output of example site (in `exampleSite/public`)
* Perform a link check for broken links, using [hyperlink](https://github.com/untitaker/hyperlink) link checker.

**Result with current code base**
```
hyperlink public/
Reading files
Checking 16902 links from 287 files (161 documents)
...
Found 316 bad links
```

**Result with this PR applied**

```
hyperlink public/
Reading files
Checking 16902 links from 287 files (161 documents)
Found 0 bad links
``` 