### PR TITLE
Update hugo to latest version 0.112.5

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,8 @@ publish = "exampleSite/public"
 command = "hugo -s exampleSite"
 
 [build.environment]
-HUGO_VERSION       = "0.111.3"
+GO_VERSION       = "1.20.4"
+HUGO_VERSION       = "0.112.5"
 HUGO_THEME         = "repo"
 HUGO_ENABLEGITINFO = "true"
 


### PR DESCRIPTION
Pleas note that build currently fails for version 0.112.5, as reported in #179. Primary motivation for this PR was to get a deployment log of the failed build on Netlify.