### PR TITLE
Fix for resource.ToCSS Deprecation in Latest Hugo

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -5,7 +5,7 @@
   </script> {{- partial "theme/meta.html" . -}}
   {{- $404sass := resources.Get "sass/theme/404.sass" -}}
   {{- $options := (dict "outputStyle" "compressed" "includePaths" (slice "assets/bulma" "assets/sass/theme")) -}}
-  {{- $main    := $404sass | resources.ExecuteAsTemplate "css/404.sass" . | resources.ToCSS $options -}}
+  {{- $main    := $404sass | resources.ExecuteAsTemplate "css/404.sass" . | css.Sass $options -}}
   <link
     rel="stylesheet"
     type="text/css"

--- a/layouts/partials/theme/includes-head.html
+++ b/layouts/partials/theme/includes-head.html
@@ -68,7 +68,7 @@
     {{- $filesArray = $filesArray | append (resources.Get .) -}}
   {{- end -}}
   {{- $options := (dict "outputStyle" "compressed" "targetPath" "css/main.css") -}}
-  {{- $cssFile := $filesArray | resources.Concat "sass/theme/bundle.sass" | resources.ToCSS $options -}}
+  {{- $cssFile := $filesArray | resources.Concat "sass/theme/bundle.sass" | css.Sass $options -}}
   <link
     rel="stylesheet"
     rel="preload"


### PR DESCRIPTION
Hello,

I recently installed Hugo and started building a page using your wonderful theme. As a beginner with Hugo, I followed the official tutorial and attempted to start the server, but I encountered the following error:

```
hugo v0.143.1+extended+withdeploy darwin/arm64 BuildDate=2025-02-04T08:57:38Z VendorInfo=brew

INFO  build:  step process substep collect files 1 files_total 1 pages_total 1 resources_total 0 duration 219.833µs
INFO  build:  step process duration 245.333µs
INFO  build:  step assemble duration 228µs
ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and subsequently removed. Use css.Sass instead.
INFO  static: syncing static files to / duration 5.024ms
INFO  build:  step render substep pages site en outputFormat html duration 239.640542ms
INFO  build:  step render substep pages site en outputFormat rss duration 565.208µs
INFO  build:  step render pages 11 content 3 duration 240.251542ms
INFO  build:  step render deferred count 0 duration 459ns
INFO  build:  step postProcess duration 3.209µs
INFO  build:  duration 240.800583ms
Built in 240 ms
Error: error building site: logged 1 error(s)
```

After investigating the issue, I found that using `resource.ToCSS` prevents the latest version of Hugo from starting properly. I was able to resolve the issue on my local environment by replacing `resource.ToCSS` with `css.Sass`.

However, since I haven't previously used this theme for an actual site, I'm unsure how this change might affect existing pages. Could you review this modification, check its impact, and merge it if there are no issues?

Thank you for your time and consideration!