### PR TITLE
Bump hugo to latest version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.133.0
+      HUGO_VERSION: 0.145.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
As seen [here](https://github.com/jgazeau/shadocs/actions/runs/13739669129/job/38427433168), deployment of example site fails with HEAD of repo.

This PR fixes that issue