### PR TITLE
chore:(ci): bump third party dependencies

### DIFF
--- a/.bmycconfig.json
+++ b/.bmycconfig.json
@@ -12,7 +12,7 @@
     "css/styles/default": {
       "local_path": "assets/css/external/asyncapi/default.min.css",
       "hold": false,
-      "current_version": "3.1.0",
+      "current_version": "3.1.2",
       "unpkg": {
         "library": "@asyncapi/react-component",
         "file_path": "styles/default.min.css"


### PR DESCRIPTION
|      Package      |                   Name                  |      Version       |  Hold |   Status   |                              Local Path/Error                             |
| :---------------: | :-------------------------------------: | :----------------: | :---: | :--------: | :-----------------------------------------------------------------------: |
|      asyncapi     |        js/asyncapi-web-component        |   2.6.5 -> 2.6.5   | False | Up to Date |         assets/js/external/asyncapi/asyncapi-web-component.min.js         |
|      asyncapi     |            css/styles/default           |   3.1.2 -> 3.1.2   | False | Up to Date |                assets/css/external/asyncapi/default.min.css               |
|     swagger-ui    |           js/swagger-ui-bundle          |  5.29.1 -> 5.29.1  | False | Up to Date |           assets/js/external/swagger-ui/swagger-ui-bundle.min.js          |
|     swagger-ui    |     js/swagger-ui-standalone-preset     |  5.29.1 -> 5.29.1  | False | Up to Date |     assets/js/external/swagger-ui/swagger-ui-standalone-preset.min.js     |
|     swagger-ui    |              css/swagger-ui             |  5.29.1 -> 5.29.1  | False | Up to Date |             assets/css/external/swagger-ui/swagger-ui.min.css             |
|     flexsearch    |           js/flexsearch.bundle          |   0.8.2 -> 0.8.2   | False | Up to Date |           assets/js/external/flexsearch/flexsearch.bundle.min.js          |
|      mermaid      |                js/mermaid               | 11.12.0 -> 11.12.0 | False | Up to Date |                 assets/js/external/mermaid/mermaid.min.js                 |
|       qrious      |                js/qrious                |   4.0.2 -> 4.0.2   | False | Up to Date |                  assets/js/external/qrious/qrious.min.js                  |
| overlayscrollbars |           js/overlayscrollbars          |  2.12.0 -> 2.12.0  | False | Up to Date |       assets/js/external/overlay-scrollbars/overlayscrollbars.min.js      |
| overlayscrollbars |          css/overlayscrollbars          |  2.12.0 -> 2.12.0  | False | Up to Date |      assets/css/external/overlay-scrollbars/overlayscrollbars.min.css     |
|       intro       |                 js/intro                |   8.3.2 -> 8.3.2   | False | Up to Date |                   assets/js/external/intro/intro.min.js                   |
|    json-editor    |              js/json-editor             |  2.15.2 -> 2.15.2  | False | Up to Date |              assets/js/external/json-editor/jsoneditor.min.js             |
|    bulma-toast    |              js/bulma-toast             |   2.4.4 -> 2.4.4   | False | Up to Date |             assets/js/external/bulma-toast/bulma-toast.min.js             |
|    fontawesome    |                 css/all                 |   7.0.1 -> 7.0.1   | False | Up to Date |                assets/css/external/fontawesome.all.min.css                |
|    fontawesome    |      static/css/fa_brands-400.woff2     |   7.0.1 -> 7.0.1   | False | Up to Date |                  static/css/webfonts/fa-brands-400.woff2                  |
|    fontawesome    |     static/css/fa_regular-400.woff2     |   7.0.1 -> 7.0.1   | False | Up to Date |                  static/css/webfonts/fa-regular-400.woff2                 |
|    fontawesome    |      static/css/fa_solid-900.woff2      |   7.0.1 -> 7.0.1   | False | Up to Date |                   static/css/webfonts/fa-solid-900.woff2                  |
|     highcharts    |              css/highcharts             |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/css/external/highcharts/highcharts.min.css             |
|     highcharts    |          css/annotations/popup          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/css/external/highcharts/annotations/popup.min.css         |
|     highcharts    |            css/stocktools/gui           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/css/external/highcharts/stocktools/gui.min.css           |
|     highcharts    |          css/themes/dark-unica          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/css/external/highcharts/themes/dark-unica.min.css         |
|     highcharts    |          css/themes/grid-light          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/css/external/highcharts/themes/grid-light.min.css         |
|     highcharts    |         css/themes/sand-signika         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/css/external/highcharts/themes/sand-signika.min.css        |
|     highcharts    |              js/highcharts              |  12.6.0 -> 12.6.0  | False | Up to Date |              assets/js/external/highcharts/highcharts.min.js              |
|     highcharts    |             js/highcharts-3d            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/highcharts-3d.min.js            |
|     highcharts    |           js/highcharts-gantt           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/highcharts-gantt.min.js           |
|     highcharts    |            js/highcharts-more           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/highcharts-more.min.js           |
|     highcharts    |               js/highmaps               |  12.6.0 -> 12.6.0  | False | Up to Date |               assets/js/external/highcharts/highmaps.min.js               |
|     highcharts    |               js/highstock              |  12.6.0 -> 12.6.0  | False | Up to Date |               assets/js/external/highcharts/highstock.min.js              |
|     highcharts    |         js/standalone-navigator         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/standalone-navigator.min.js         |
|     highcharts    |         js/modules/accessibility        |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/accessibility.min.js        |
|     highcharts    |          js/modules/annotations         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/annotations.min.js         |
|     highcharts    |     js/modules/annotations-advanced     |  12.6.0 -> 12.6.0  | False | Up to Date |     assets/js/external/highcharts/modules/annotations-advanced.min.js     |
|     highcharts    |          js/modules/arc-diagram         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/arc-diagram.min.js         |
|     highcharts    |         js/modules/arrow-symbols        |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/arrow-symbols.min.js        |
|     highcharts    |             js/modules/boost            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/modules/boost.min.js            |
|     highcharts    |         js/modules/boost-canvas         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/boost-canvas.min.js         |
|     highcharts    |          js/modules/broken-axis         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/broken-axis.min.js         |
|     highcharts    |            js/modules/bullet            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/bullet.min.js            |
|     highcharts    |           js/modules/coloraxis          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/coloraxis.min.js          |
|     highcharts    |            js/modules/contour           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/contour.min.js           |
|     highcharts    |    js/modules/current-date-indicator    |  12.6.0 -> 12.6.0  | False | Up to Date |    assets/js/external/highcharts/modules/current-date-indicator.min.js    |
|     highcharts    |           js/modules/cylinder           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/cylinder.min.js           |
|     highcharts    |             js/modules/data             |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/modules/data.min.js             |
|     highcharts    |          js/modules/data-tools          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/data-tools.min.js          |
|     highcharts    |         js/modules/datagrouping         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/datagrouping.min.js         |
|     highcharts    |           js/modules/debugger           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/debugger.min.js           |
|     highcharts    |       js/modules/dependency-wheel       |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/modules/dependency-wheel.min.js       |
|     highcharts    |            js/modules/dotplot           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/dotplot.min.js           |
|     highcharts    |          js/modules/drag-panes          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/drag-panes.min.js          |
|     highcharts    |       js/modules/draggable-points       |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/modules/draggable-points.min.js       |
|     highcharts    |           js/modules/drilldown          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/drilldown.min.js          |
|     highcharts    |           js/modules/dumbbell           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/dumbbell.min.js           |
|     highcharts    |          js/modules/export-data         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/export-data.min.js         |
|     highcharts    |           js/modules/exporting          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/exporting.min.js          |
|     highcharts    |            js/modules/flowmap           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/flowmap.min.js           |
|     highcharts    |          js/modules/full-screen         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/full-screen.min.js         |
|     highcharts    |            js/modules/funnel            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/funnel.min.js            |
|     highcharts    |           js/modules/funnel3d           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/funnel3d.min.js           |
|     highcharts    |             js/modules/gantt            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/modules/gantt.min.js            |
|     highcharts    |          js/modules/geoheatmap          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/geoheatmap.min.js          |
|     highcharts    |           js/modules/grid-axis          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/grid-axis.min.js          |
|     highcharts    |            js/modules/heatmap           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/heatmap.min.js           |
|     highcharts    |          js/modules/heikinashi          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/heikinashi.min.js          |
|     highcharts    |      js/modules/histogram-bellcurve     |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/modules/histogram-bellcurve.min.js     |
|     highcharts    |       js/modules/hollowcandlestick      |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/modules/hollowcandlestick.min.js      |
|     highcharts    |          js/modules/item-series         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/item-series.min.js         |
|     highcharts    |           js/modules/lollipop           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/lollipop.min.js           |
|     highcharts    |              js/modules/map             |  12.6.0 -> 12.6.0  | False | Up to Date |              assets/js/external/highcharts/modules/map.min.js             |
|     highcharts    |        js/modules/marker-clusters       |  12.6.0 -> 12.6.0  | False | Up to Date |        assets/js/external/highcharts/modules/marker-clusters.min.js       |
|     highcharts    |       js/modules/mouse-wheel-zoom       |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/modules/mouse-wheel-zoom.min.js       |
|     highcharts    |           js/modules/navigator          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/navigator.min.js          |
|     highcharts    |         js/modules/networkgraph         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/networkgraph.min.js         |
|     highcharts    |      js/modules/no-data-to-display      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/modules/no-data-to-display.min.js      |
|     highcharts    |      js/modules/non-cartesian-zoom      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/modules/non-cartesian-zoom.min.js      |
|     highcharts    |       js/modules/offline-exporting      |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/modules/offline-exporting.min.js      |
|     highcharts    |         js/modules/organization         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/organization.min.js         |
|     highcharts    |     js/modules/parallel-coordinates     |  12.6.0 -> 12.6.0  | False | Up to Date |     assets/js/external/highcharts/modules/parallel-coordinates.min.js     |
|     highcharts    |            js/modules/pareto            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/pareto.min.js            |
|     highcharts    |          js/modules/pathfinder          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/pathfinder.min.js          |
|     highcharts    |         js/modules/pattern-fill         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/pattern-fill.min.js         |
|     highcharts    |           js/modules/pictorial          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/pictorial.min.js          |
|     highcharts    |        js/modules/pointandfigure        |  12.6.0 -> 12.6.0  | False | Up to Date |        assets/js/external/highcharts/modules/pointandfigure.min.js        |
|     highcharts    |        js/modules/price-indicator       |  12.6.0 -> 12.6.0  | False | Up to Date |        assets/js/external/highcharts/modules/price-indicator.min.js       |
|     highcharts    |           js/modules/pyramid3d          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/pyramid3d.min.js          |
|     highcharts    |             js/modules/renko            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/modules/renko.min.js            |
|     highcharts    |            js/modules/sankey            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/sankey.min.js            |
|     highcharts    |         js/modules/series-label         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/series-label.min.js         |
|     highcharts    |        js/modules/series-on-point       |  12.6.0 -> 12.6.0  | False | Up to Date |        assets/js/external/highcharts/modules/series-on-point.min.js       |
|     highcharts    |          js/modules/solid-gauge         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/solid-gauge.min.js         |
|     highcharts    |         js/modules/sonification         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/sonification.min.js         |
|     highcharts    |         js/modules/static-scale         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/static-scale.min.js         |
|     highcharts    |             js/modules/stock            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/modules/stock.min.js            |
|     highcharts    |          js/modules/stock-tools         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/stock-tools.min.js         |
|     highcharts    |          js/modules/streamgraph         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/streamgraph.min.js         |
|     highcharts    |           js/modules/sunburst           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/sunburst.min.js           |
|     highcharts    |           js/modules/textpath           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/textpath.min.js           |
|     highcharts    |          js/modules/tiledwebmap         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/modules/tiledwebmap.min.js         |
|     highcharts    |            js/modules/tilemap           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/tilemap.min.js           |
|     highcharts    |           js/modules/timeline           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/timeline.min.js           |
|     highcharts    |           js/modules/treegraph          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/treegraph.min.js          |
|     highcharts    |           js/modules/treegrid           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/treegrid.min.js           |
|     highcharts    |            js/modules/treemap           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/treemap.min.js           |
|     highcharts    |         js/modules/variable-pie         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/modules/variable-pie.min.js         |
|     highcharts    |           js/modules/variwide           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/variwide.min.js           |
|     highcharts    |            js/modules/vector            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/vector.min.js            |
|     highcharts    |             js/modules/venn             |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/modules/venn.min.js             |
|     highcharts    |           js/modules/windbarb           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/windbarb.min.js           |
|     highcharts    |           js/modules/wordcloud          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/modules/wordcloud.min.js          |
|     highcharts    |            js/modules/xrange            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/modules/xrange.min.js            |
|     highcharts    |     js/indicators/acceleration-bands    |  12.6.0 -> 12.6.0  | False | Up to Date |     assets/js/external/highcharts/indicators/acceleration-bands.min.js    |
|     highcharts    | js/indicators/accumulation-distribution |  12.6.0 -> 12.6.0  | False | Up to Date | assets/js/external/highcharts/indicators/accumulation-distribution.min.js |
|     highcharts    |             js/indicators/ao            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/indicators/ao.min.js            |
|     highcharts    |            js/indicators/apo            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/apo.min.js            |
|     highcharts    |           js/indicators/aroon           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/indicators/aroon.min.js           |
|     highcharts    |      js/indicators/aroon-oscillator     |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/aroon-oscillator.min.js     |
|     highcharts    |            js/indicators/atr            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/atr.min.js            |
|     highcharts    |      js/indicators/bollinger-bands      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/bollinger-bands.min.js      |
|     highcharts    |            js/indicators/cci            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/cci.min.js            |
|     highcharts    |          js/indicators/chaikin          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/indicators/chaikin.min.js          |
|     highcharts    |            js/indicators/cmf            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/cmf.min.js            |
|     highcharts    |            js/indicators/cmo            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/cmo.min.js            |
|     highcharts    |            js/indicators/dema           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/dema.min.js           |
|     highcharts    |      js/indicators/disparity-index      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/disparity-index.min.js      |
|     highcharts    |            js/indicators/dmi            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/dmi.min.js            |
|     highcharts    |            js/indicators/dpo            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/dpo.min.js            |
|     highcharts    |     js/indicators/ichimoku-kinko-hyo    |  12.6.0 -> 12.6.0  | False | Up to Date |     assets/js/external/highcharts/indicators/ichimoku-kinko-hyo.min.js    |
|     highcharts    |         js/indicators/indicators        |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/indicators/indicators.min.js        |
|     highcharts    |       js/indicators/indicators-all      |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/indicators/indicators-all.min.js      |
|     highcharts    |      js/indicators/keltner-channels     |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/keltner-channels.min.js     |
|     highcharts    |          js/indicators/klinger          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/indicators/klinger.min.js          |
|     highcharts    |            js/indicators/macd           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/macd.min.js           |
|     highcharts    |            js/indicators/mfi            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/mfi.min.js            |
|     highcharts    |          js/indicators/momentum         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/indicators/momentum.min.js         |
|     highcharts    |            js/indicators/natr           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/natr.min.js           |
|     highcharts    |            js/indicators/obv            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/obv.min.js            |
|     highcharts    |        js/indicators/pivot-points       |  12.6.0 -> 12.6.0  | False | Up to Date |        assets/js/external/highcharts/indicators/pivot-points.min.js       |
|     highcharts    |            js/indicators/ppo            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/ppo.min.js            |
|     highcharts    |       js/indicators/price-channel       |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/indicators/price-channel.min.js       |
|     highcharts    |      js/indicators/price-envelopes      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/price-envelopes.min.js      |
|     highcharts    |            js/indicators/psar           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/psar.min.js           |
|     highcharts    |        js/indicators/regressions        |  12.6.0 -> 12.6.0  | False | Up to Date |        assets/js/external/highcharts/indicators/regressions.min.js        |
|     highcharts    |            js/indicators/roc            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/roc.min.js            |
|     highcharts    |            js/indicators/rsi            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/rsi.min.js            |
|     highcharts    |      js/indicators/slow-stochastic      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/slow-stochastic.min.js      |
|     highcharts    |         js/indicators/stochastic        |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/indicators/stochastic.min.js        |
|     highcharts    |         js/indicators/supertrend        |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/indicators/supertrend.min.js        |
|     highcharts    |            js/indicators/tema           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/tema.min.js           |
|     highcharts    |         js/indicators/trendline         |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/indicators/trendline.min.js         |
|     highcharts    |            js/indicators/trix           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/trix.min.js           |
|     highcharts    |      js/indicators/volume-by-price      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/indicators/volume-by-price.min.js      |
|     highcharts    |            js/indicators/vwap           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/vwap.min.js           |
|     highcharts    |         js/indicators/williams-r        |  12.6.0 -> 12.6.0  | False | Up to Date |         assets/js/external/highcharts/indicators/williams-r.min.js        |
|     highcharts    |            js/indicators/wma            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/indicators/wma.min.js            |
|     highcharts    |           js/indicators/zigzag          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/indicators/zigzag.min.js          |
|     highcharts    |            js/themes/adaptive           |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/themes/adaptive.min.js           |
|     highcharts    |            js/themes/avocado            |  12.6.0 -> 12.6.0  | False | Up to Date |            assets/js/external/highcharts/themes/avocado.min.js            |
|     highcharts    |           js/themes/brand-dark          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/themes/brand-dark.min.js          |
|     highcharts    |          js/themes/brand-light          |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/themes/brand-light.min.js          |
|     highcharts    |           js/themes/dark-blue           |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/themes/dark-blue.min.js           |
|     highcharts    |           js/themes/dark-green          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/themes/dark-green.min.js          |
|     highcharts    |           js/themes/dark-unica          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/themes/dark-unica.min.js          |
|     highcharts    |              js/themes/gray             |  12.6.0 -> 12.6.0  | False | Up to Date |              assets/js/external/highcharts/themes/gray.min.js             |
|     highcharts    |              js/themes/grid             |  12.6.0 -> 12.6.0  | False | Up to Date |              assets/js/external/highcharts/themes/grid.min.js             |
|     highcharts    |           js/themes/grid-light          |  12.6.0 -> 12.6.0  | False | Up to Date |           assets/js/external/highcharts/themes/grid-light.min.js          |
|     highcharts    |       js/themes/high-contrast-dark      |  12.6.0 -> 12.6.0  | False | Up to Date |       assets/js/external/highcharts/themes/high-contrast-dark.min.js      |
|     highcharts    |      js/themes/high-contrast-light      |  12.6.0 -> 12.6.0  | False | Up to Date |      assets/js/external/highcharts/themes/high-contrast-light.min.js      |
|     highcharts    |          js/themes/sand-signika         |  12.6.0 -> 12.6.0  | False | Up to Date |          assets/js/external/highcharts/themes/sand-signika.min.js         |
|     highcharts    |             js/themes/skies             |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/themes/skies.min.js             |
|     highcharts    |             js/themes/sunset            |  12.6.0 -> 12.6.0  | False | Up to Date |             assets/js/external/highcharts/themes/sunset.min.js            |

|   Total    | Count |
| :--------: | :---: |
|   Error    |   0   |
|  Outdated  |   0   |
|  Updated   |   0   |
| Up-to-date |  170  |